### PR TITLE
Initial sketch of automated testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+/node_modules

--- a/detector.js
+++ b/detector.js
@@ -1,0 +1,7 @@
+window.MozillaVaultDetector = function() {
+  return {
+    login: "#login_field",
+    password: "#password",
+    submit: ".submit_btn > input"
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "skycrane-detector",
+    "version": "0.0.1",
+    "private": true,
+    "dependencies": {
+    },
+    "devDependencies": {
+      "vows": "0.6.4",
+      "wd": "0.0.25",
+      "optimist": "0.3.5",
+      "q": "0.8.9",
+      "underscore": "1.4.2"
+    },
+    "scripts": {
+    },
+    "engines": {
+        "node": ">= 0.8.11"
+    }
+}

--- a/tests/basic-test.js
+++ b/tests/basic-test.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const
+path = require('path'),
+assert = require('assert'),
+utils = require('./lib/utils.js'),
+runner = require('./lib/runner.js'),
+testSetup = require('./lib/test-setup.js'),
+injector = require('./lib/injector.js');
+
+var browser;
+
+runner.run(module, {
+  "setup": function(done) {
+    testSetup.setup({browsers: 1, personatestusers: 2}, function(err, fixtures) {
+      browser = fixtures.browsers[0];
+      done(err);
+    });
+  },
+  "create a new selenium session": function(done) {
+    browser.newSession(testSetup.sessionOpts, done);
+  },
+  "load github login screen": function(done) {
+    browser.get("https://github.com/login", done);
+  },
+  "inject detector javascript and cause it to run": function(done) {
+    injector.injectVault(browser, function(err, val) {
+      assert.equal(null, err);
+      injector.injectFile(browser, path.join(__dirname, "browser-harness.js"), function(err, val) {
+        assert.equal(null, err);
+        done();
+      });
+    });
+  },
+  "verify elements were detected in page": function(done) {
+    browser.find(".mozVaultDetectedLoginField", function(err, elem) {
+      assert.ok(!err);
+      assert.ok(elem);
+      browser.find(".mozVaultDetectedPasswordField", function(err, elem) {
+        assert.ok(!err);
+        assert.ok(elem);
+        browser.find(".mozVaultDetectedSubmitButton", function(err, elem) {
+          assert.ok(!err);
+          assert.ok(elem);
+          done();
+        });
+      });
+    });
+  },
+  "mfb tear down browser": function(done) {
+    browser.quit(done);
+  }
+});

--- a/tests/browser-harness.js
+++ b/tests/browser-harness.js
@@ -1,0 +1,14 @@
+(function() {
+  try {
+    var ids = MozillaVaultDetector();
+    document.querySelector(ids.login).style.backgroundColor = "red";
+    document.querySelector(ids.login).className += " mozVaultDetectedLoginField";
+    document.querySelector(ids.password).style.backgroundColor = "green";
+    document.querySelector(ids.password).className += " mozVaultDetectedPasswordField";
+    document.querySelector(ids.submit).style.backgroundColor = "yellow";
+    document.querySelector(ids.submit).className += " mozVaultDetectedSubmitButton";
+  } catch(e) {
+    return false;
+  }
+  return true;
+})();

--- a/tests/lib/injector.js
+++ b/tests/lib/injector.js
@@ -1,0 +1,13 @@
+var fs = require('fs'),
+  path = require('path');
+
+exports.injectVault = function(browser, cb) {
+  exports.injectFile(browser, path.join(__dirname, "..", "..", "detector.js"), cb);
+};
+
+exports.injectFile = function(browser, file, cb) {
+  fs.readFile(file, function(err, contents) {
+    if (err) return cb(err);
+    browser.eval(contents, cb);
+  });
+};

--- a/tests/lib/reporters/file_reporter.js
+++ b/tests/lib/reporters/file_reporter.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+
+function FileReporter(config) {
+  var fileName = config.output_path;
+
+  var pathParts = fileName.split('/');
+  // Ensure that all the directories in the path exist.
+  // the last portion of the path will be the filename, remove it.
+  pathParts.pop();
+
+  var directoryPath = "";
+  pathParts.forEach(function(directoryName) {
+    directoryPath += "/" + directoryName;
+    if (fs.existsSync(directoryPath)) {
+      var directoryStats = fs.statSync(directoryPath);
+
+      // If this path exists but is not a directory, we have a problems.
+      if (!directoryStats.isDirectory()) {
+        throw new Error("Cannot create directory: " + directoryPath);
+      }
+    }
+    else {
+      fs.mkdirSync(directoryPath, "0744");
+    }
+  });
+
+  this.fd = fs.openSync(fileName, "a");
+}
+FileReporter.prototype.report = function(msg) {
+  fs.writeSync(this.fd, msg, 0, msg.length, null);
+};
+FileReporter.prototype.done = function() {
+  fs.closeSync(this.fd);
+};
+
+module.exports = FileReporter;

--- a/tests/lib/reporters/std_err_reporter.js
+++ b/tests/lib/reporters/std_err_reporter.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const util = require('util');
+
+function StdErrReporter() { }
+StdErrReporter.prototype.report = function(msg) {
+  util.error(msg);
+};
+StdErrReporter.prototype.done = function() {};
+
+module.exports = StdErrReporter;

--- a/tests/lib/reporters/std_out_reporter.js
+++ b/tests/lib/reporters/std_out_reporter.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const util = require('util');
+
+function StdOutReporter() { }
+StdOutReporter.prototype.report = function(msg) {
+  util.print(msg);
+};
+StdOutReporter.prototype.done = function() {};
+
+module.exports = StdOutReporter;
+

--- a/tests/lib/runner.js
+++ b/tests/lib/runner.js
@@ -1,0 +1,31 @@
+const vowsHarness = require('../lib/vows_harness.js');
+
+var alltests = {},
+  rawSuites = [],
+  globalCount = 0;
+
+// register just pushes suites onto a master list
+function register(suites) {
+  if (!suites.length) { suites = [suites] }
+  rawSuites = rawSuites.concat(suites)
+}
+
+// run runs previously-registered suites. for convenience,
+// you can just pass suites into run as well.
+function run(mod, suites) {
+  if (suites) register(suites);
+
+  rawSuites.forEach(function(suite, i) {
+    for (var vow in suite) {
+      globalCount++;
+      // vows with duplicate names cause great sadness; use a counter to ensure
+      // each name is unique
+      alltests[globalCount + ': ' + vow] = suite[vow];
+    }
+  });
+
+  vowsHarness(alltests, mod); // todo where is module defined?
+}
+
+exports.run = run;
+exports.register = register;

--- a/tests/lib/sauce-platforms.js
+++ b/tests/lib/sauce-platforms.js
@@ -1,0 +1,64 @@
+// platforms supported by sauce that we test
+const platforms = {
+  "linux_firefox_13": {
+    platform: 'LINUX',
+    browserName: 'firefox',
+    version: '13'
+  },
+  "linux_opera_12": {
+    platform: 'LINUX',
+    browserName: 'opera',
+    version: '12'
+  },
+  "osx_firefox_14": {
+    platform: 'MAC',
+    browserName:'firefox',
+    version:'14'
+  },
+  "vista_chrome": {
+    platform:'VISTA',
+    browserName:'chrome'
+  },
+  "vista_firefox_13": {
+    platform:'VISTA',
+    browserName:'firefox',
+    version:'13'
+  },
+  "vista_ie_9": {
+    platform:'VISTA',
+    browserName:'internet explorer',
+    version:'9'
+  },
+  "xp_ie_8": {
+    platform:'XP',
+    browserName: 'internet explorer',
+    version:'8'
+  },
+  "osx_safari_5": {
+    platform:'Mac 10.6',
+    browserName: 'safari',
+    version:'5'
+  },
+  "iphone_safari_5": {
+    platform:'Mac 10.6',
+    browserName: 'iphone',
+    version:'5'
+  },
+  "ipad_safari_5": {
+    platform:'Mac 10.6',
+    browserName: 'ipad',
+    version:'5'
+  },
+  "android_4": {
+    platform:'Linux',
+    browserName: 'android',
+    version:'4'
+  }
+}
+
+const defaultCapabilities = {
+  avoidProxy: true,
+};
+
+exports.platforms = platforms;
+exports.defaultCapabilities = defaultCapabilities;

--- a/tests/lib/test-setup.js
+++ b/tests/lib/test-setup.js
@@ -1,0 +1,141 @@
+const
+Q = require('q'),
+saucePlatforms = require('./sauce-platforms.js'),
+wd = require('wd'),
+_ = require('underscore');
+
+require('./wd-extensions.js');
+
+var testSetup = {};
+
+const TEST_TAG = "detector";
+
+// startup determines if browser sessions will be local or use saucelabs.
+// should only be called once per session (potentially, once for many tests)
+//
+// saucelabs is used if:
+//  - opts include sauceUser and sauceApiKey or
+//  - env vars include PERSONA_SAUCE_USER and PERSONA_SAUCE_APIKEY
+//
+// opts may also include
+//  - platform (a browser from the list in lib/sauce_platforms)
+//  - desiredCapabilities (see json wire protocol for list of capabilities)
+// env var equivalents are PERSONA_BROWSER and PERSONA_BROWSER_CAPABILITIES
+testSetup.startup = function(opts) {
+  opts = opts || {};
+  _setSessionOpts(opts);
+
+  var sauceUser = opts.sauceUser || process.env['PERSONA_SAUCE_USER'],
+    sauceApiKey = opts.sauceApiKey || process.env['PERSONA_SAUCE_APIKEY'],
+    browser;
+
+  if (sauceUser && sauceApiKey) {
+    browser = wd.remote('ondemand.saucelabs.com', 80, sauceUser, sauceApiKey);
+    browser.on('status', function(info){
+      // using console.error so we don't mix up plain text with junitxml
+      info = info.trim();
+      // for the first message, let's print out a URL that can be loaded
+      // rather an opaque status message.
+      if (info.split(" ")[0] == "Driving") {
+        var url = "https://saucelabs.com/tests/" + info.split(" ")[5];
+        console.error('\n\x1b[36m%s\x1b[0m: %s\n', "Running", url);
+      } else {
+        console.error('\n\x1b[36m%s\x1b[0m\n', info);
+      }
+    });
+    if (process.env['DEBUG_TESTS']) {
+      browser.on('command', function(method, path){
+        console.log(method, path);
+      });
+    };
+  } else {
+    browser = wd.remote();
+  }
+
+  var id = testSetup.browsers.push(browser);
+  return id - 1;
+}
+
+// store multiple browsers until we can switch between sessions via d
+testSetup.browsers = []
+
+// these session opts aren't needed until the user requests a session via newSession()
+// but we harvest them from the command line at startup time
+function _setSessionOpts(opts) {
+  opts = opts || {};
+  var sessionOpts = {};
+
+  // check for typos: throw error if requestedPlatform not found in list of supported sauce platforms
+  var requestedPlatform = opts.platform || process.env['PERSONA_BROWSER'];
+  if (requestedPlatform && !saucePlatforms.platforms[requestedPlatform]) {
+    throw new Error('requested platform ' + requestedPlatform +
+                    ' not found in list of available platforms');
+  }
+  // Default to chrome which does not need a version number.
+  var defaultPlatform = { browserName: 'chrome', platform: 'VISTA' };
+  var platform = requestedPlatform ? saucePlatforms.platforms[requestedPlatform] : defaultPlatform;
+
+  // add platform, browserName, version to session opts
+  _.extend(sessionOpts, platform);
+
+  // pull the default desired capabilities out of the sauce-platforms file
+  // overwrite if specified by user
+  var desiredCapabilities = opts.desiredCapabilities || process.env['PERSONA_BROWSER_CAPABILITIES'] || {};
+  _.extend(sessionOpts, saucePlatforms.defaultCapabilities);
+  _.extend(sessionOpts, desiredCapabilities);
+
+  if (sessionOpts.browserName === 'opera' && !sessionOpts.proxy) {
+    // TODO reportedly works for opera; investigate
+    sessionOpts.proxy = { proxyType: 'direct' };
+  }
+
+  // Ensure there is a tag.
+  sessionOpts.tags = sessionOpts.tags || [];
+  if (sessionOpts.tags.indexOf(TEST_TAG) === -1) {
+    sessionOpts.tags.push(TEST_TAG);
+  }
+
+  sessionOpts.public = sessionOpts.public || true;
+
+  testSetup.sessionOpts = sessionOpts;
+}
+
+// opts could be of the form:
+// { browsers: 2 }
+// or of the form
+// { b:2 }
+// just be polite and don't mix the two.
+//
+// cb could be of the form:
+// function(err, fixtures) {
+//   // either these are global or you declared them in outer scope
+//   browser = fixtures.browsers[0];
+//   secondBrowser = fixtures.browsers[1];
+// }
+testSetup.setup = function(opts, cb) {
+  var fixtures = {},
+    browsers = opts.browsers || opts.b,
+    promises = [];
+
+  // no need to return a promise, just fire the cb when ready
+  if (promises) {
+    Q.all(promises)
+      .then(function() {
+        fixtures = setupBrowsers(browsers, fixtures);
+        cb(null, fixtures);
+      })
+      .fail(function(error) { cb(error) });
+  } else {
+    fixtures = setupBrowsers(browsers, fixtures);
+    cb(null, fixtures)
+  }
+}
+
+function setupBrowsers(browserCount, out) {
+  for (var i = 0; i < browserCount; i++) { testSetup.startup() }
+  // just use the browsers array directly
+  out.b = out.browsers = testSetup.browsers;
+  return out;
+}
+
+module.exports = testSetup;

--- a/tests/lib/test_finder.js
+++ b/tests/lib/test_finder.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const path   = require('path'),
+      fs     = require('fs'),
+      test_root_path = path.join(__dirname, "..", "tests"),
+      tests_to_ignore = require('../config/tests-to-ignore').tests_to_ignore;
+
+exports.find = function(root, tests) {
+  root = root || test_root_path;
+  tests = tests || [];
+
+  try {
+    var files = fs.readdirSync(root);
+    files.forEach(function(file) {
+      var filePath = path.join(root, file);
+      var stats = fs.lstatSync(filePath);
+      if (stats.isFile()) {
+        if (/\.js$/.test(file)) {
+          if (tests_to_ignore.indexOf(file) === -1) {
+            tests.push({
+              name: file.replace('.js', ''),
+              path: filePath
+            });
+          }
+          else {
+            console.log("ignoring", file);
+          }
+        }
+      }
+      else if (stats.isDirectory()) {
+        exports.find(filePath, tests);
+      }
+
+    });
+  } catch(e) {
+    console.log(e.toString());
+    return;
+  }
+
+  return tests;
+};

--- a/tests/lib/timeouts.js
+++ b/tests/lib/timeouts.js
@@ -1,0 +1,2 @@
+exports.DEFAULT_POLL_MS = 500;
+exports.DEFAULT_TIMEOUT_MS = 20000;

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -1,0 +1,21 @@
+// wait for something to work.
+//   poll - how often to check in ms
+//   timeout - how long to try before giving up in ms
+//   check - a function that will perform the check, accepts a callback where the
+//           first argument is a boolean indicating whether the check was successful
+//           (if false, the check will be retried)
+//   complete - a callback to invoke upon timeout or successful check with args.slice(1)
+//           from the check function
+exports.waitFor = function (poll, timeout, check, complete) {
+  var startTime = new Date();
+  function doit() {
+    check(function(done) {
+      if (done || ((new Date() - startTime) > timeout)) {
+        complete.apply(null, Array.prototype.slice.call(arguments, 1));
+      } else {
+        setTimeout(doit, poll);
+      }
+    });
+  }
+  setTimeout(doit, poll);
+};

--- a/tests/lib/vows_harness.js
+++ b/tests/lib/vows_harness.js
@@ -1,0 +1,33 @@
+var vows = require('vows'),
+    path = require('path'),
+    assert = require('assert');
+
+module.exports = function(spec, mod) {
+  var suite = vows.describe(path.basename(process.argv[1]));
+  suite.options.error = false;
+
+  var lastArgs = [];
+  Object.keys(spec).forEach(function(name) {
+    var obj = {};
+    obj[name] = {
+      topic: function() {
+        var self = this;
+        var args = lastArgs.slice(1);
+        // add a "done" function as the first argument
+        args.unshift(function() {
+          // invoke callback with all these arguments
+          lastArgs = Array.prototype.slice.call(arguments, 0);
+          self.callback.apply(self, lastArgs);
+        });
+        spec[name].apply(this, args);
+      },
+      "succeeds": function(err) {
+        assert(!err, err);
+      }
+    };
+    suite.addBatch(obj);
+  });
+
+  if (process.argv[1] === __filename) suite.run();
+  else suite.export(mod);
+};

--- a/tests/lib/wd-extensions.js
+++ b/tests/lib/wd-extensions.js
@@ -1,0 +1,193 @@
+// add helper routines onto wd that make common operations easy to do
+// correctly
+
+var wd = require('wd/lib/webdriver.js');
+
+const utils = require('./utils.js'),
+   timeouts = require('./timeouts.js'),
+   platforms = require('./sauce-platforms.js'),
+   path = require('path');
+
+function setTimeouts(opts) {
+  opts.poll = opts.poll || timeouts.DEFAULT_POLL_MS;
+  opts.timeout = opts.timeout || timeouts.DEFAULT_TIMEOUT_MS;
+}
+
+function createTestName(opts) {
+  var testname = path.basename(path.normalize(process.argv[1])) || '';
+  testname = testname.replace(/\.js$/, '');
+  return [ 'skycrane', testname ].join('.').replace(/\s/g, '_');
+}
+
+// wait for a element to become part of the dom and be visible to
+// the user.  The element is identified by CSS selector.  options:
+//   which: css selector specifying which element
+//   poll (optional):
+//   timeout (optional)
+wd.prototype.waitForDisplayed = function(opts, cb) {
+  if (typeof opts == 'string') opts = { which: opts };
+  if (!opts.which) throw "css selector required";
+  setTimeouts(opts);
+  var browser = this;
+
+  utils.waitFor(opts.poll, opts.timeout, function(done) {
+    browser.elementByCss(opts.which, function(err, elem) {
+      if (err) return done(!err, err, elem);
+      browser.displayed(elem, function(err, displayed) {
+        done(!err && displayed, err, elem);
+      });
+    })
+  }, cb);
+};
+
+// allocate a new browser session and sets implicit wait timeout
+wd.prototype.newSession = function(opts, cb) {
+  var browser = this;
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {};
+  }
+
+  if (!opts.name) opts.name = createTestName(opts);
+
+  browser.init(opts, function(err) {
+    if (err) return cb(err);
+    // note!  the implicit wait timeout is different from other timeouts,
+    // it's the amount of time certain wire transactions will wait for
+    // procedures like find_element to succeed (we'll actually wait on the
+    // *server* side for an element to become visible).  Having this be
+    // the same as the global default timeout is interesting.
+    browser.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, cb);
+  });
+};
+
+// wait for a window, specified by name, to become visible and switch to it
+//  .waitForWindow(<name>, <cb>)
+//  or
+//  .waitForWindow(<opts>, <cb>)
+//
+// If the latter invocation is employed, you can specify .poll and .timeout
+// values.
+wd.prototype.waitForWindow = function(opts, cb) {
+  if (typeof opts == 'string') opts = { name: opts };
+  if (!opts.name) throw "waitForWindow missing window `name`";
+  var browser = this;
+
+  setTimeouts(opts);
+  utils.waitFor(opts.poll, opts.timeout, function(done) {
+    browser.window(opts.name, function(err) {
+      done(!err, err);
+    });
+  }, cb);
+};
+
+// close the currently open browser window and switch to one of the remaining
+// open windows (deterministic if you know that exactly two windows are open)
+wd.prototype.closeCurrentBrowserWindow = function(cb) {
+  var self = this;
+  self.close(function(err) {
+    if (err) return cb(err);
+    self.windowHandles(function(err, data) {
+      if (err) return cb(err);
+      if (data.length < 1) return cb("no window to switch to!");
+      self.window(data[0], cb);
+    });
+  });
+};
+
+// wait for an element, specified by CSS selector, to have a non-empty text value.
+//  .waitForWindow(<selector>, <cb>)
+//  or
+//  .waitForWindow(<opts>, <cb>)
+
+wd.prototype.waitForElementText = function(opts, cb) {
+  var self = this;
+  if (typeof(opts) === 'string') opts = { which: opts };
+  setTimeouts(opts);
+  utils.waitFor(opts.poll, opts.timeout, function(done) {
+    self.elementByCss(opts.which, function(err, elem) {
+      if (err) return done(false, err, elem);
+      self.text(elem, function(err, text) {
+        done(!err && typeof text === 'string' && text.length, err, text);
+      });
+    });
+  }, cb);
+};
+
+
+// convenience methods
+wd.prototype.wfind = wd.prototype.waitForDisplayed;
+wd.prototype.find = wd.prototype.elementByCss;
+
+// convenience method to switch windows
+//
+// if no arguments are passed, switch to the base window--in a dialog flow,
+// this will be the zeroth window in the list of handles.
+//
+// if arguments are passed in, they are forwarded to waitForWindow.
+wd.prototype.wwin = function(opts, cb) {
+  var self = this;
+
+  // special case where just the callback was passed: go to the zeroth window
+  if (arguments.length == 1 && typeof arguments[0] == 'function') {
+    var cb = arguments[0];
+    self.windowHandles(function(err, handles) {
+      if (err) return cb(err);
+      self.window(handles[0], function(err) { cb(err) }); // fire cb whether err is defined or not
+    });
+  } else {
+    self.waitForWindow(opts, cb)
+  }
+}
+
+// wait for element to be displayed, then click on it.
+// optionally accepts waitForDisplayed opts object instead of CSS selector
+wd.prototype.wclick = function(opts, cb) {
+  var self = this;
+  self.waitForDisplayed(opts, function(err, el) {
+    if (err) return cb(err);
+    self.clickElement(el, cb);
+  });
+};
+
+wd.prototype.click = function(which, cb) {
+  var self = this;
+  self.elementByCss(which, function(err, el) {
+    if (err) return cb(err);
+    self.clickElement(el, cb);
+  });
+};
+
+// wait for an element to be displayed, then type in it.
+wd.prototype.wtype = function(opts, text, cb) {
+  var self = this;
+  self.waitForDisplayed(opts, function(err, el) {
+    if (err) return cb(err);
+    self.type(el, text, cb);
+  });
+};
+
+// wait then return visible text for an element
+wd.prototype.wtext = function(opts, cb) {
+  var self = this;
+  self.waitForDisplayed(opts, function(err, el) {
+    if (err) return cb(err);
+    self.text(el, cb);
+  });
+};
+
+// delay before the next action
+wd.prototype.delay = function(duration, cb) {
+  var self = this;
+
+  setTimeout(cb, duration);
+};
+
+// wait then clear an input element
+wd.prototype.wclear = function(opts, cb) {
+  var self = this;
+  self.waitForDisplayed(opts, function(err, el) {
+    if (err) return cb(err);
+    self.clear(el, cb);
+  });
+};


### PR DESCRIPTION
`basic-test.js` is a test of the detection's engines ability to detect login forms on github.  Run it directly after npm install.  It will require sauclabs credentials set in your environment and will output a url you can load to see test results.

`detector.js` is a stub of the detection engine that returns found selectors.

`tests/browser-harness.js` is a selenium-specific wrapper that invokes `detector.js`, colors fields, and then adds a class to them.

make sense?
